### PR TITLE
feat: add user confirmation prompt before deleting a book #19

### DIFF
--- a/src/Library.java
+++ b/src/Library.java
@@ -81,8 +81,17 @@ public class Library {
         Optional<Book> optionalBook = bookRepository.findById(id);
 
         if (optionalBook.isPresent()) {
-            bookRepository.delete(id);
-            System.out.println("Book checked out successfully.");
+            Book book = optionalBook.get();
+            System.out.println("Book found: " + book.getTitle());
+            System.out.print("Are you sure you want to check out this book? (Y/N): ");
+            String confirmation = scanner.nextLine().trim();
+
+            if ("Y".equalsIgnoreCase(confirmation)) {
+                bookRepository.delete(id);
+                System.out.println("Book checked out successfully.");
+            } else {
+                System.out.println("Checkout canceled.");
+            }
         } else {
             System.out.println("Book not found.");
         }


### PR DESCRIPTION
Added a confirmation prompt (Y/N) before a book is deleted from the list.
This ensures that users do not accidentally remove entries. The logic includes:
- A simple prompt to confirm deletion
- Graceful handling of invalid input
- Book is only removed when user explicitly confirms with 'Y' or 'y'

Closes #19